### PR TITLE
Update deps to latest for NodeJS v16 support.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,241 @@
+{
+  "name": "node-red-contrib-widgetlords",
+  "version": "1.3.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-red-contrib-widgetlords",
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "ffi-napi": "^4.0.3",
+        "ref-napi": "^3.0.3",
+        "ref-struct-di": "^1.1.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/ffi-napi": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
+      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1 || ^3.0.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ffi-napi/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ffi-napi/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "node_modules/get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "dependencies": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/ref-napi": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/ref-napi/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ref-napi/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "dependencies": {
+        "debug": "^3.1.0"
+      }
+    }
+  },
+  "dependencies": {
+    "debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "ffi-napi": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/ffi-napi/-/ffi-napi-4.0.3.tgz",
+      "integrity": "sha512-PMdLCIvDY9mS32RxZ0XGb95sonPRal8aqRhLbeEtWKZTe2A87qRFG9HjOhvG8EX2UmQw5XNRMIOT+1MYlWmdeg==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-uv-event-loop-napi-h": "^1.0.5",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1",
+        "ref-napi": "^2.0.1 || ^3.0.2",
+        "ref-struct-di": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "get-symbol-from-current-process-h": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz",
+      "integrity": "sha512-syloC6fsCt62ELLrr1VKBM1ggOpMdetX9hTrdW77UQdcApPHLmf7CI7OKcN1c9kYuNxKcDe4iJ4FY9sX3aw2xw=="
+    },
+    "get-uv-event-loop-napi-h": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz",
+      "integrity": "sha512-t5c9VNR84nRoF+eLiz6wFrEp1SE2Acg0wS+Ysa2zF0eROes+LzOfuTaVHxGy8AbS8rq7FHEJzjnCZo1BupwdJg==",
+      "requires": {
+        "get-symbol-from-current-process-h": "^1.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
+    },
+    "ref-napi": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "get-symbol-from-current-process-h": "^1.0.2",
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ref-struct-di": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
+      "requires": {
+        "debug": "^3.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,31 +5,34 @@
   "author": "widgetlords",
   "license": "MIT",
   "homepage": "https://widgetlords.com",
-  "keywords": [ "node-red", "widgetlords" ],
+  "keywords": [
+    "node-red",
+    "widgetlords"
+  ],
   "node-red": {
     "nodes": {
-      	"widgetlords-pi-spi-digital": "pi-spi/digital.js",
-      	"widgetlords-pi-spi-relay": "pi-spi/relay.js",
-      	"widgetlords-pi-spi-analog-in": "pi-spi/analog-in.js",
-      	"widgetlords-pi-spi-analog-out": "pi-spi/analog-out.js",
-        "widgetlords-pi-spi-8ai-16b": "pi-spi/8ai-16b.js",
-        "widgetlords-analog-in": "pi-spi-din/analog-in.js",
-        "widgetlords-analog-out": "pi-spi-din/analog-out.js",
-        "widgetlords-digital": "pi-spi-din/digital.js",
-        "widgetlords-pi-spi-din-4freq": "pi-spi-din/4freq.js",
-      	"widgetlords-relay": "pi-spi-din/relay.js",
-      	"widgetlords-vpe-3011b-digital": "vpe-3011b/digital.js",
-      	"widgetlords-vpe-3011b-relay": "vpe-3011b/relay.js",
-      	"widgetlords-vpe-3011b-sdafe": "vpe-3011b/sdafe.js",
-      	"widgetlords-vpe-2901a-digital": "vpe-2901a/digital.js",
-      	"widgetlords-vpe-2901a-relay": "vpe-2901a/relay.js",
-      	"widgetlords-vpe-2901a-sdafe": "vpe-2901a/sdafe.js",
-      	"widgetlords-vpe-2901a-analog-out": "vpe-2901a/analog-out.js"
+      "widgetlords-pi-spi-digital": "pi-spi/digital.js",
+      "widgetlords-pi-spi-relay": "pi-spi/relay.js",
+      "widgetlords-pi-spi-analog-in": "pi-spi/analog-in.js",
+      "widgetlords-pi-spi-analog-out": "pi-spi/analog-out.js",
+      "widgetlords-pi-spi-8ai-16b": "pi-spi/8ai-16b.js",
+      "widgetlords-analog-in": "pi-spi-din/analog-in.js",
+      "widgetlords-analog-out": "pi-spi-din/analog-out.js",
+      "widgetlords-digital": "pi-spi-din/digital.js",
+      "widgetlords-pi-spi-din-4freq": "pi-spi-din/4freq.js",
+      "widgetlords-relay": "pi-spi-din/relay.js",
+      "widgetlords-vpe-3011b-digital": "vpe-3011b/digital.js",
+      "widgetlords-vpe-3011b-relay": "vpe-3011b/relay.js",
+      "widgetlords-vpe-3011b-sdafe": "vpe-3011b/sdafe.js",
+      "widgetlords-vpe-2901a-digital": "vpe-2901a/digital.js",
+      "widgetlords-vpe-2901a-relay": "vpe-2901a/relay.js",
+      "widgetlords-vpe-2901a-sdafe": "vpe-2901a/sdafe.js",
+      "widgetlords-vpe-2901a-analog-out": "vpe-2901a/analog-out.js"
     }
   },
   "dependencies": {
-    "ffi-napi": "^2.4.0",
-    "ref-napi": "^1.4.0",
+    "ffi-napi": "^4.0.3",
+    "ref-napi": "^3.0.3",
     "ref-struct-di": "^1.1.0"
   }
 }


### PR DESCRIPTION
Updates dependencies to latest versions as current version causes Node Red to crash while running NodeJS 16.  

Confirmed dep updates work as expected on following components:

PI-SPI-DIN-2x4MIO
PI-SPI-DIN-4KO
PI-SPI-DIN-4AO
PI-SPI-DIN-8AI
PI-SPI-DIN-8DI

**Confirmed System Configurations with fresh installs:**

Node Red v2.1.3
NodeJS v12.22.7 / v14.18.1 / v16.13.0
Debian Bullseye 64bit Lite

Node Red v2.1.3
NodeJS v12.22.7 / v14.18.1 / v16.13.0
Debian Bullseye 32bit Lite

Node Red v2.1.3
NodeJS v12.22.7
Debian Buster 32bit Lite